### PR TITLE
global configuration options for express-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ module.exports.post = {
 };
 ```
 
-### Status codes and text
+### Specific Status codes and text
 By default, the status code is set to `400`, and status text to `Bad Request`, you can change this behaviour with the following:
 
 ```js
@@ -181,6 +181,22 @@ module.exports.post = {
   ...
 };
 ```
+
+### Global options
+Status code and text can also be customized globally. At the same time specific behaviour still applies.
+
+```js
+var ev = require('express-validation');
+// assign options
+ev.options({
+  status: 422,
+  statusText: 'Unprocessable Entity'
+});
+
+// clear options back to default
+ev.options();
+```
+Thanks to node `require()` caching, all the other `express-validation` instances also have the same set of global options.
 
 ## Working with headers
 When creating a validation object that checks `req.headers`; please remember to use `lowercase` names; node.js will convert incoming headers to lowercase:
@@ -198,6 +214,7 @@ module.exports = {
 ```
 
 ## Changelog
+0.4.1: added `options()` method to [globally override configuration](#global-options).
 0.4.0: `express-validation` now returns a `ValidationError`, not a simple `Error`. This offer some advantages [when writing error handlers](#distinguish-errors-from-validationerrors).  
 0.3.0: prior to version 0.3.0, we returned a json error response straight out of the middleware, this changed in 0.3.0 to allow the express application itself to return the error response.  So from 0.3.0 onwards, you will need to add an express error handler, and return an error response.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,17 @@ ValidationError.prototype.toJSON = function () {
   return response;
 };
 
+var defOptions = {
+  flatten: false,
+  allowUnknownHeaders: true,
+  allowUnknownBody: true,
+  allowUnknownQuery: true,
+  allowUnknownParams: true,
+  status: 400,
+  statusText: 'Bad Request'
+};
+var globalOptions = {};
+
 exports = module.exports = function (schema) {
   if (!schema) { 
     throw new Error("Please provide a validation schema"); 
@@ -74,17 +85,7 @@ exports = module.exports = function (schema) {
     };
 
     // Set default options
-    var options = schema.options || {};
-
-    options = _.defaults(options, {
-      flatten: false,
-      allowUnknownHeaders: true,
-      allowUnknownBody: true,
-      allowUnknownQuery: true,
-      allowUnknownParams: true,
-      status: 400,
-      statusText: 'Bad Request'
-    });
+    var options = schema.options ? _.defaults({}, schema.options, globalOptions, defOptions) : _.defaults({}, globalOptions, defOptions);
 
     pushErrors(errors, validate(errors, req.headers, schema.headers, 'headers', options.allowUnknownHeaders));
     pushErrors(errors, validate(errors, req.body, schema.body, 'body', options.allowUnknownBody));
@@ -98,3 +99,10 @@ exports = module.exports = function (schema) {
   };
 };
 exports.ValidationError = ValidationError;
+exports.options = function (opts) {
+  if (!opts) {
+    globalOptions = {};
+    return;
+  }
+  globalOptions = _.extend({}, globalOptions, opts);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-validation",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Andrew Keig <andrew.keig@gmail.com>",
   "description": "express-validation is a middleware that validates the body, params, query, headers of a request and returns a response with errors; if any of the configured validation rules fail.",
   "homepage": "https://github.com/andrewkeig/express-validation",

--- a/test/options.js
+++ b/test/options.js
@@ -48,3 +48,56 @@ describe('schema options', function () {
     });
   })
 });
+
+describe('global options', function () {
+
+  describe('when the user globally setups some options', function () {
+
+    it('they should be inherited by every validation instance', function () {
+
+      validation.options({
+        status: 422
+      });
+
+      var validationFn = validation(require('./validation/login'));
+      var fakeReq = {
+        body: {
+          email: "andrew.keiggmail.com",
+          password: "12356"
+        }
+      };
+
+      validationFn(fakeReq, undefined, function next (err) {
+        err.errors.length.should.equal(1);
+        err.status.should.equal(422);
+        err.statusText.should.equal('Bad Request');
+      });
+    });
+  });
+
+  describe('when user decides to reset options to default', function () {
+
+    it('should be able to reset options on demand', function () {
+
+      validation.options({
+        status: 422
+      });
+
+      validation.options();
+
+      var validationFn = validation(require('./validation/login'));
+      var fakeReq = {
+        body: {
+          email: "andrew.keiggmail.com",
+          password: "12356"
+        }
+      };
+
+      validationFn(fakeReq, undefined, function next (err) {
+        err.errors.length.should.equal(1);
+        err.status.should.equal(400);
+        err.statusText.should.equal('Bad Request');
+      });
+    });
+  });
+});


### PR DESCRIPTION
resolves #6 

2 notes:
  * [index.js#line-61](https://github.com/mrgamer/express-validation/commit/9f549e28021c10cb27d7a9de92c6a6ce8b13746b#diff-6d186b954a58d5bb740f73d84fe39073R61) this lodash.defaults line is as elegant as I could make it, main point is: first parameters should _always_ be `{}` otherwise lodash overwrites original object (I wasted almost an hour nailing it down smoothly)

  * tests are not done with supertest because I needed to re-declare the `/login` endpoint (it gets created at tests runtime, and does _not_ see my `globalOptions` override)
I hope you like them, since in this way they are also synchronous!

EDIT:
I haven't edited documentation, I was not sure about my english. If you require it, just write me and I'll update the PR