### PR TITLE
errors thrown by the library are now ValidationErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ Running the above test will produce the following response.
 }
 ```
 
+## Distinguish `Error`(s) from `ValidationError`(s)
+Since 0.4.0 `express-validation` calls `next()` with a `ValidationError`, a specific type of `Error`.  
+This can be very handy when writing more complex error handlers for your Express application, a brief example follows:
+
+```js
+var ev = require('express-validation');
+
+// error handler
+app.use(function (err, req, res, next) {
+  // specific for validation errors
+  if (err istanceof ev.ValidationError) return res.status(err.status).json(err);
+
+  // other type of errors, it *might* also be a Runtime Error
+  // example handling
+  if (process.env.NODE_ENV !== 'production') {
+    return res.status(500).send(err.stack);
+  } else {
+    return res.status(500);
+  }
+});
+```
+
 ## Options
 
 ### Simple error response

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ module.exports = {
 ```
 
 ## Changelog
+0.4.0: `express-validation` now returns a `ValidationError`, not a simple `Error`. This offer some advantages [when writing error handlers](#distinguish-errors-from-validationerrors).  
 0.3.0: prior to version 0.3.0, we returned a json error response straight out of the middleware, this changed in 0.3.0 to allow the express application itself to return the error response.  So from 0.3.0 onwards, you will need to add an express error handler, and return an error response.
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,35 @@
 
 var Joi = require('joi');
 var _ = require('lodash');
+var util = require('util');
 
-module.exports = function (schema) {
+var ValidationError = function (errors, options) {
+  this.message = 'validation error';
+  Error.call(this);
+  this.errors = errors;
+  this.flatten = options.flatten;
+  this.status = options.status;
+  this.statusText = options.statusText;
+};
+util.inherits(ValidationError, Error);
+ValidationError.prototype.toString = function () {
+  return JSON.stringify(this.toJSON());
+};
+ValidationError.prototype.toJSON = function () {
+  var response = {
+    status : this.status,
+    statusText : this.statusText,
+    errors : this.errors
+  };
+
+  if (this.flatten){
+    response = _.flatten(_.pluck(this.errors, 'messages'));
+  }
+
+  return response;
+};
+
+exports = module.exports = function (schema) {
   if (!schema) { 
     throw new Error("Please provide a validation schema"); 
   }
@@ -67,17 +94,7 @@ module.exports = function (schema) {
     if (errors && errors.length === 0) {
       return next();
     }
-
-    var response = {
-      status : options.status,
-      statusText : options.statusText,
-      errors : errors
-    };
-
-    if (options.flatten){
-      response = _.flatten(_.pluck(errors, 'messages'));
-    }
-
-    return next(response);
+    return next(new ValidationError(errors, options));
   };
 };
+exports.ValidationError = ValidationError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-validation",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Andrew Keig <andrew.keig@gmail.com>",
   "description": "express-validation is a middleware that validates the body, params, query, headers of a request and returns a response with errors; if any of the configured validation rules fail.",
   "homepage": "https://github.com/andrewkeig/express-validation",

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var validation = require('../lib/index')
+  , should = require('should');
+
+describe('when library throws an error', function () {
+
+  it('should call next() with a ValidationError', function () {
+    var validationHandler = validation(require('./validation/login'));
+    var fakeReq = {
+      body: {
+        email: "andrew.keiggmail.com",
+        password: "12356"
+      }
+    };
+
+    validationHandler(fakeReq, undefined, function next (err) {
+      err.should.be.instanceof(validation.ValidationError);
+      err.errors.length.should.equal(1);
+      err.status.should.equal(400);
+      err.statusText.should.equal('Bad Request');
+    });
+  });
+
+  it('should be compatible with javascript Error', function () {
+    var validationHandler = validation(require('./validation/login'));
+    var fakeReq = {
+      body: {
+        email: "andrew.keiggmail.com",
+        password: "12356"
+      }
+    };
+
+    validationHandler(fakeReq, undefined, function next (err) {
+      err.should.be.instanceof(Error);
+      err.errors.length.should.equal(1);
+      err.status.should.equal(400);
+      err.statusText.should.equal('Bad Request');
+    });
+  });
+
+  it('should not have a stack trace, since is not a coding error', function () {
+    var validationHandler = validation(require('./validation/login'));
+    var fakeReq = {
+      body: {
+        email: "andrew.keiggmail.com",
+        password: "12356"
+      }
+    };
+
+    validationHandler(fakeReq, undefined, function next (err) {
+      err.should.not.have.keys('stack');
+      err.errors.length.should.equal(1);
+      err.status.should.equal(400);
+      err.statusText.should.equal('Bad Request');
+    });
+  });
+});


### PR DESCRIPTION
Proposing this PR since I think distinguish `Error(s)` from `ValidationError(s)` can be very productive when writing an express errorHandler.

`Error(s)` could also be coding errors, so I would very much differentiate between those 2 types.

An additional note: in my fork I have made this branch (`typed-error`) that is for your `master` branch, in case you also accept PR #7 I have made another branch (`options-and-errors`) that makes #7 compatible with #8

Hope you like my work