### PR TITLE
Feat/error types

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Running the above test will produce the following response.
       "messages": [
         "the value of password is not allowed to be empty",
         "the value of password must match the regular expression /[a-zA-Z0-9]{3,30}/"
-      ]
+      ],
+      types: [ 'any.empty', 'string.regex.base' ]
     }
   ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,13 +66,14 @@ exports = module.exports = function (schema) {
           var errorExists = _.find(current, function(item){ 
             if (item && item.field === error.path && item.location === location) {
               item.messages.push(error.message);
+              item.types.push(error.type);
               return item;
             }
             return;
           });
 
           if (!errorExists) {
-            current.push({ field : error.path, location : location, messages : [error.message]});
+            current.push({ field : error.path, location : location, messages : [error.message], types:[error.type]});
           }
 
         }, errors);

--- a/test/body.js
+++ b/test/body.js
@@ -66,6 +66,7 @@ describe('validate body', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(2);
+          response.errors[0].types.length.should.equal(2);
           done();
         });
       });
@@ -88,7 +89,9 @@ describe('validate body', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(2);
           response.errors[0].messages.length.should.equal(2);
+          response.errors[0].types.length.should.equal(2);
           response.errors[1].messages.length.should.equal(2);
+          response.errors[1].types.length.should.equal(2);
           done();
         });
       });
@@ -112,6 +115,7 @@ describe('validate body', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(1);
+          response.errors[0].types.length.should.equal(1);
           done();
         });
       });

--- a/test/headers.js
+++ b/test/headers.js
@@ -35,6 +35,7 @@ describe('validate headers', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(1);
+          response.errors[0].types.length.should.equal(1);
           done();
         });
       });

--- a/test/mix.js
+++ b/test/mix.js
@@ -49,6 +49,7 @@ describe('validate a mixture of request types', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(1);
+          response.errors[0].types.length.should.equal(1);
           response.errors[0].field.should.equal('id')
           done();
         });


### PR DESCRIPTION
Hi,

I added a `types` key underneath the error, this enables users to use these as indicators for internationalisation of error messages.
Where the `messages` array was tested in the tests i also included a similar test for the new `types` array + added sample output in the README.md

I don't know if this change is acceptable to this project.. it should be backward compatible. (All tests pass without any modification, you can verify this by running the tests after applying `2c809a9`)

If you want me to change something or add an option or .. give me a shout.

Thanks,
Stefan