### PR TITLE
Extend request variable in validate() to add support for defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,12 +57,12 @@ exports = module.exports = function (schema) {
       if (!request || !schema) {
         return;
       }
-
+      
       Joi.validate(request, schema, {allowUnknown : allowUnknown, abortEarly : false}, function(errors, value){
         if (!errors || errors.details.length === 0) {
+          _.extend(request, value);
           return;
         }
-
         _.each(errors.details, function(error){
           var errorExists = _.find(current, function(item){
             if (item && item.field === error.path && item.location === location) {

--- a/test/app.js
+++ b/test/app.js
@@ -41,6 +41,10 @@ app.post('/options', validate(validation.options), function(req, res){
     res.json(200);
 })
 
+app.post('/defaults', validate(validation.defaults), function(req, res) {  
+  res.json(req.body);
+})
+
 app.post('/logout', validate(validation.logout), function(req, res){
     res.json(200)
 })

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var validation = require('../lib/index')
+, app = require('./app')
+, should = require('should')
+, request = require('supertest');
+
+describe.only('set default values', function() {  
+  describe('when the values are  missing', function() {
+  // Expect default values to be set
+    it('should return the request with default values', function(done) {
+      request(app)
+        .post('/defaults')
+        .send({firstname: "Jane", lastname: "Doe"})
+        .expect(200)
+        .end(function (err, res) {
+          var response = JSON.parse(res.text);
+          response.username.should.equal("jane-doe");
+          done();
+        });  
+    });
+  });
+
+})

--- a/test/validation/defaults.js
+++ b/test/validation/defaults.js
@@ -1,0 +1,19 @@
+var Joi = require('joi');
+
+var generateUsername = function(context) {
+  return context.firstname.toLowerCase() + '-' + context.lastname.toLowerCase();
+}
+
+generateUsername.description = "generated username";
+module.exports = {
+  body: {
+    username: Joi.string().default(generateUsername),
+    firstname: Joi.string(),
+    lastname: Joi.string(),
+    created: Joi.date().default(Date.now, 'time of creation'),
+    status: Joi.string().default('registered'),   
+    registered: Joi.boolean().default(true),
+    type: Joi.string().when('registered', {is: true, then: Joi.default('registered'), otherwise: Joi.default('unregistered')}),
+    values: Joi.array().default(['1'])
+  }
+}

--- a/test/validation/index.js
+++ b/test/validation/index.js
@@ -7,3 +7,4 @@ exports.account = require('./account');
 exports.register = require('./register');
 exports.options = require('./options');
 exports.logout = require('./logout');
+exports.defaults = require('./defaults');


### PR DESCRIPTION
The way things are now, you are losing Joi.default() values because of your middleware. With this change, the final value is extended with the values from defaults and will be available in the body, query params, or wherever. Let me know if you want me to add more extensive tests.