### PR TITLE
Replace params values also so they are converted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ exports = module.exports = function (schema) {
     pushErrors(errors, validate(errors, req.headers, schema.headers, 'headers', options.allowUnknownHeaders));
     pushErrors(errors, validate(errors, req.body, schema.body, 'body', options.allowUnknownBody));
     pushErrors(errors, validate(errors, req.query, schema.query, 'query', options.allowUnknownQuery));
-    pushErrors(errors, validate(errors, _.isNull(req.params) || _.isUndefined(req.params) ? {} : req.params, schema.params, 'params', options.allowUnknownParams));
+    pushErrors(errors, validate(errors, _.isPlainObject(req.params) ? req.params : {}, schema.params, 'params', options.allowUnknownParams));
     pushErrors(errors, validate(errors, req.cookies, schema.cookies, 'cookies', options.allowUnknownCookies));
 
     if (errors && errors.length === 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ exports = module.exports = function (schema) {
     pushErrors(errors, validate(errors, req.headers, schema.headers, 'headers', options.allowUnknownHeaders));
     pushErrors(errors, validate(errors, req.body, schema.body, 'body', options.allowUnknownBody));
     pushErrors(errors, validate(errors, req.query, schema.query, 'query', options.allowUnknownQuery));
-    pushErrors(errors, validate(errors, _.extend({}, req.params), schema.params, 'params', options.allowUnknownParams));
+    pushErrors(errors, validate(errors, _.isNull(req.params) || _.isUndefined(req.params) ? {} : req.params, schema.params, 'params', options.allowUnknownParams));
     pushErrors(errors, validate(errors, req.cookies, schema.cookies, 'cookies', options.allowUnknownCookies));
 
     if (errors && errors.length === 0) {

--- a/test/app.js
+++ b/test/app.js
@@ -22,7 +22,9 @@ app.get('/user', validate(validation.user.get), function(req, res){
 });
 
 app.get('/account/:id', validate(validation.account), function(req, res){
-    res.json(200);
+  res.json({
+    id: req.params.id
+  });
 });
 
 app.get('/search', validate(validation.search), function(req, res){

--- a/test/params.js
+++ b/test/params.js
@@ -14,8 +14,7 @@ describe('validate params', function () {
         .get('/account/1')
         .expect(200)
         .end(function (err, res) {
-          var response = JSON.parse(res.text);
-          response.should.equal(200);
+          res.body.id.should.equal(1);
           done();
         });
       });
@@ -28,8 +27,7 @@ describe('validate params', function () {
         .get('/account/a')
         .expect(400)
         .end(function (err, res) {
-          var response = JSON.parse(res.text);
-          response.errors.length.should.equal(1);
+          res.body.errors.length.should.equal(1);
           done();
         });
       });


### PR DESCRIPTION
This avoids the _.extend of the params, since that negates the _.extend in the validate method of the converted and defaulted values.

I changed the return a bit to be able to get the params back. I don't think the status code needs to be returned in the body also, since it is already validated in the .expect(200).