### PR TITLE
Fix: ValidationError to inherit from Error

### DIFF
--- a/lib/validation-error.js
+++ b/lib/validation-error.js
@@ -3,13 +3,14 @@ var map = require('lodash/map');
 var flatten = require('lodash/flatten');
 
 function ValidationError (errors, options) {
-  this.message = 'validation error';
+  Error.call(this, 'validation error');
   this.errors = errors;
   this.flatten = options.flatten;
   this.status = options.status;
   this.statusText = options.statusText;
 };
 ValidationError.prototype = Object.create(Error.prototype);
+ValidationError.prototype.constructor = Error;
 
 ValidationError.prototype.toString = function () {
   return JSON.stringify(this.toJSON());


### PR DESCRIPTION
`ValidationError` does not correctly inherits from `Error` 
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Classical_inheritance_with_Object.create()

This causes this strange behabiour

``` js
let error = new ValidationError(...);
error instanceof Error // true
error.stack // undefined
error.name // undefined
```
