### PR TITLE
feat: Allow customization for ValidationError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports = module.exports = function (schema) {
 
     if (errors && errors.length === 0) return next();
 
-    return next(new ValidationError(errors, options));
+    return next(new exports.ValidationError(errors, options));
   };
 };
 


### PR DESCRIPTION
Allow users to implement their Error instead of stacking to the internal implementation

``` js
var validate = require('express-validation');

class MyFancyValidationError extends Error { ... }

validate.ValidationError = MyFancyValidationError;
```
