### PR TITLE
ValidationError name propery added

### DIFF
--- a/lib/validation-error.js
+++ b/lib/validation-error.js
@@ -3,6 +3,7 @@ var map = require('lodash/map');
 var flatten = require('lodash/flatten');
 
 function ValidationError (errors, options) {
+  this.name = 'ValidationError';
   this.message = 'validation error';
   this.errors = errors;
   this.flatten = options.flatten;


### PR DESCRIPTION
following the example of other express middleware validation libraries like [express-jwt](https://github.com/auth0/express-jwt/blob/master/lib/errors/UnauthorizedError.js)
it will be more consistent if the ValidationError class has a prop called name
