### PR TITLE
Use Joi mutation instead of copying keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var Joi = require('joi');
-var assignIn = require('lodash/assignIn');
 var find = require('lodash/find');
 var defaults = require('lodash/defaults');
 var ValidationError = require('./validation-error');
@@ -39,7 +38,7 @@ exports = module.exports = function (schema) {
     ['headers', 'body', 'query', 'params', 'cookies'].forEach(function (key) {
       var allowUnknown = options[unknownMap[key]];
       var entireContext = options.contextRequest ? req : null;
-      if (schema[key]) validate(errors, req[key], schema[key], key, allowUnknown, entireContext);
+      if (schema[key]) validate(errors, req, schema, key, allowUnknown, entireContext);
     });
 
     if (errors && errors.length === 0) return next();
@@ -64,17 +63,17 @@ exports.options = function (opts) {
  * NOTE: mutates `request` in case the object is valid.
  */
 function validate (errObj, request, schema, location, allowUnknown, context) {
-  if (!request || !schema) return;
+  if (!request[location] || !schema[location]) return;
 
   var joiOptions = {
-    context: context || request,
+    context: context || request[location],
     allowUnknown: allowUnknown,
     abortEarly: false
   };
 
-  Joi.validate(request, schema, joiOptions, function (errors, value) {
+  Joi.validate(request[location], schema[location], joiOptions, function (errors, value) {
     if (!errors || errors.details.length === 0) {
-      assignIn(request, value); // joi responses are parsed into JSON
+      request[location] = value;
       return;
     }
     errors.details.forEach(function (error) {

--- a/test/app.js
+++ b/test/app.js
@@ -43,6 +43,9 @@ app.post('/logout', validate(validation.logout), respond200);
 app.post('/array', validate(validation.array), respond200);
 app.post('/context/:id', validate(validation.context), respond200);
 
+app.post('/strip', validate(validation.strip), respondWith('body'));
+app.post('/rename', validate(validation.rename), respondWith('body'));
+
 // default errorhandler for express-validation
 app.use(function (err, req, res, next) {
   res.status(400).json(err);

--- a/test/app.js
+++ b/test/app.js
@@ -45,6 +45,7 @@ app.post('/context/:id', validate(validation.context), respond200);
 
 app.post('/strip', validate(validation.strip), respondWith('body'));
 app.post('/rename', validate(validation.rename), respondWith('body'));
+app.post('/empty', validate(validation.empty), respondWith('body'));
 
 // default errorhandler for express-validation
 app.use(function (err, req, res, next) {

--- a/test/keys.js
+++ b/test/keys.js
@@ -33,4 +33,23 @@ describe('for schema that remove keys', function () {
         });
     });
   });
+  
+  describe('when the schema contains an .empty() predicate', function () {
+    it('should remove that key when it is empty', function (done) {
+      request(app)
+        .post('/empty')
+        .send(
+        { 
+          iAmEmpty: '',
+          iAmNotEmpty: 'Text'
+        })
+        .expect(200)
+        .end(function (err, res) {
+          var response = JSON.parse(res.text);
+          response.should.not.have.property('iAmEmpty');
+          response.iAmNotEmpty.should.be.equal('Text');
+          done();
+        });
+    });
+  });
 });

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,0 +1,36 @@
+require('should');
+var app = require('./app');
+var request = require('supertest');
+
+describe('for schema that remove keys', function () {
+
+  describe('when the schema contains a .strip() predicate', function () {
+    it('should remove that key on validation', function (done) {
+      request(app)
+        .post('/strip')
+        .send({ stripMe: 'I should disappear' })
+        .expect(200)
+        .end(function (err, res) {
+          var response = JSON.parse(res.text);
+          response.should.not.have.property('stripMe');
+          done();
+        });
+    });
+  });
+
+  describe('when the schema contains a .rename() predicate', function () {
+    it('should move that key on validation', function (done) {
+      request(app)
+        .post('/rename')
+        .send({ renameMe: 'I should reappear' })
+        .expect(200)
+        .end(function (err, res) {
+          var response = JSON.parse(res.text);
+          response.should.not.have.property('renameMe');
+          response.should.have.property('renamedTo');
+          response.renamedTo.should.be.equal('I should reappear');
+          done();
+        });
+    });
+  });
+});

--- a/test/validation/empty.js
+++ b/test/validation/empty.js
@@ -1,0 +1,8 @@
+var Joi = require('joi');
+
+module.exports = {
+  body: {
+    iAmEmpty: Joi.any().empty(''),
+    iAmNotEmpty: Joi.any().empty('')
+  }
+};

--- a/test/validation/index.js
+++ b/test/validation/index.js
@@ -11,3 +11,5 @@ exports.parsing = require('./parsing');
 exports.register = require('./register');
 exports.search = require('./search');
 exports.user = require('./user');
+exports.strip = require('./strip');
+exports.rename = require('./rename');

--- a/test/validation/index.js
+++ b/test/validation/index.js
@@ -13,3 +13,4 @@ exports.search = require('./search');
 exports.user = require('./user');
 exports.strip = require('./strip');
 exports.rename = require('./rename');
+exports.empty = require('./empty');

--- a/test/validation/rename.js
+++ b/test/validation/rename.js
@@ -1,0 +1,5 @@
+var Joi = require('joi');
+
+module.exports = {
+  body: Joi.object().keys().rename('renameMe', 'renamedTo')
+};

--- a/test/validation/strip.js
+++ b/test/validation/strip.js
@@ -1,0 +1,7 @@
+var Joi = require('joi');
+
+module.exports = {
+  body: {
+    stripMe: Joi.any().strip()
+  }
+};


### PR DESCRIPTION
Copy the Joi result directly into the request object instead of copying the keys.

Fixes #45 
