### PR TITLE
feat: Added name to validation-error

### DIFF
--- a/lib/validation-error.js
+++ b/lib/validation-error.js
@@ -3,6 +3,7 @@ var map = require('lodash/map');
 var flatten = require('lodash/flatten');
 
 function ValidationError (errors, options) {
+  this.name = 'ValidationError'
   this.message = 'validation error';
   this.errors = errors;
   this.flatten = options.flatten;

--- a/lib/validation-error.js
+++ b/lib/validation-error.js
@@ -3,7 +3,7 @@ var map = require('lodash/map');
 var flatten = require('lodash/flatten');
 
 function ValidationError (errors, options) {
-  this.name = 'ValidationError'
+  this.name = 'ValidationError';
   this.message = 'validation error';
   this.errors = errors;
   this.flatten = options.flatten;


### PR DESCRIPTION
Some other express middleware is using error names to be able to discovered, just for the sake of having everything i would add this.

You can then check instead of `err instanceof validate.ValidationError`  with `err.name === 'ValidationError'`