### PR TITLE
Add koa support

### DIFF
--- a/koa.js
+++ b/koa.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/koa');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,7 @@
 'use strict';
-var Joi = require('joi');
-var assignIn = require('lodash/assignIn');
-var find = require('lodash/find');
 var defaults = require('lodash/defaults');
 var ValidationError = require('./validation-error');
+var validate = require('./validate');
 
 var defaultOptions = {
   contextRequest: false,
@@ -57,45 +55,4 @@ exports.options = function (opts) {
   }
 
   globalOptions = defaults({}, globalOptions, opts);
-};
-
-/**
- * validate checks the current `Request` for validations
- * NOTE: mutates `request` in case the object is valid.
- */
-function validate (errObj, request, schema, location, allowUnknown, context) {
-  if (!request || !schema) return;
-
-  var joiOptions = {
-    context: context || request,
-    allowUnknown: allowUnknown,
-    abortEarly: false
-  };
-
-  Joi.validate(request, schema, joiOptions, function (errors, value) {
-    if (!errors || errors.details.length === 0) {
-      assignIn(request, value); // joi responses are parsed into JSON
-      return;
-    }
-    errors.details.forEach(function (error) {
-      var errorExists = find(errObj, function (item) {
-        if (item && item.field === error.path && item.location === location) {
-          item.messages.push(error.message);
-          item.types.push(error.type);
-          return item;
-        }
-        return;
-      });
-
-      if (!errorExists) {
-        errObj.push({
-          field: error.path,
-          location: location,
-          messages: [error.message],
-          types: [error.type]
-        });
-      }
-
-    });
-  });
 };

--- a/lib/koa.js
+++ b/lib/koa.js
@@ -1,0 +1,45 @@
+'use strict';
+var defaults = require('lodash/defaults');
+var includes = require('lodash/includes');
+var ValidationError = require('./validation-error');
+var validate = require('./validate');
+
+var defaultOptions = {
+  rejectUnknown: [],
+  status: 400,
+  statusText: 'Bad Request'
+};
+
+var globalOptions = {};
+
+module.exports = function (schema, userOpts) {
+  if (!schema) throw new Error('Please provide a validation schema');
+
+  return function (ctx, next)  {
+    var errors = [];
+
+    // Set default options
+    var options = defaults({}, userOpts || {}, globalOptions, defaultOptions);
+
+    // NOTE: mutates `errors`
+    Object.keys(schema).forEach(function (key) {
+      var allowUnknown = !includes(options.rejectUnknown, key);
+      if (schema[key]) validate(errors, ctx.request[key], schema[key], key, allowUnknown, ctx);
+    });
+
+    if (errors && errors.length === 0) return next();
+
+    ctx.throw(new ValidationError(errors, options));
+  };
+};
+
+module.exports.ValidationError = ValidationError;
+
+module.exports.options = function (opts) {
+  if (!opts) {
+    globalOptions = {};
+    return;
+  }
+
+  globalOptions = defaults({}, globalOptions, opts);
+};

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,0 +1,45 @@
+'use strict';
+var Joi = require('joi');
+var find = require('lodash/find');
+var assignIn = require('lodash/assignIn');
+
+/**
+ * validate checks the current `Request` for validations
+ * NOTE: mutates `request` in case the object is valid.
+ */
+module.exports = function validate (errObj, request, schema, location, allowUnknown, context) {
+  if (!request || !schema) return;
+
+  var joiOptions = {
+    context: context || request,
+    allowUnknown: allowUnknown,
+    abortEarly: false
+  };
+
+  Joi.validate(request, schema, joiOptions, function (errors, value) {
+    if (!errors || errors.details.length === 0) {
+      assignIn(request, value); // joi responses are parsed into JSON
+      return;
+    }
+    errors.details.forEach(function (error) {
+      var errorExists = find(errObj, function (item) {
+        if (item && item.field === error.path && item.location === location) {
+          item.messages.push(error.message);
+          item.types.push(error.type);
+          return item;
+        }
+        return;
+      });
+
+      if (!errorExists) {
+        errObj.push({
+          field: error.path,
+          location: location,
+          messages: [error.message],
+          types: [error.type]
+        });
+      }
+
+    });
+  });
+};


### PR DESCRIPTION
Hi, I added koa support, but I'm not sure how and where to write document...

I added `koa.js` in module root and required `lib/koa.js`, so user can use it easily: `require('express-validation/koa')`

I splited `validate` into a separate file, so `lib/index` and `lib/koa` can both use it.

The default function receive two argument: `schema` and `options`, so we can know what property user want to validate in `ctx.request` (because there is no convention about the name of the url parameter, some router named `query`, some router named `params`)

I changed `allowUnknownHeaders`, `allowUnknownBody`, `allowUnknownQuery`, `allowUnknownParams`, `allowUnknownCookies` to `rejectUnknown: ['headers', ...]`. And removed `contextRequest`, make `joiOptions.context` always be `ctx`

That's all.