### PR TITLE
Ensure stack trace is captured

### DIFF
--- a/lib/validation-error.js
+++ b/lib/validation-error.js
@@ -1,15 +1,17 @@
 'use strict';
 var map = require('lodash/map');
 var flatten = require('lodash/flatten');
+var util = require('util');
 
 function ValidationError (errors, options) {
+  Error.captureStackTrace(this, this.constructor);
   this.message = 'validation error';
   this.errors = errors;
   this.flatten = options.flatten;
   this.status = options.status;
   this.statusText = options.statusText;
 };
-ValidationError.prototype = Object.create(Error.prototype);
+util.inherits(ValidationError, Error);
 
 ValidationError.prototype.toString = function () {
   return JSON.stringify(this.toJSON());


### PR DESCRIPTION
This ensures the stack-trace is captured when the ValidationError is created. This helps when later logging and reporting the error to f.ex. Rollbar.