### PR TITLE
Proposal: export `validate` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Example without `express-validation`:
 app.post('/login', function(req, res){
   console.log(req.body); // => '{ "email": "user@domain", "password": "pwd" }'
   res.json(200);
-});
+});`
 ```
 
 Example with `express-validation`:
@@ -239,10 +239,33 @@ app.use(function (err, req, res, next) {
 });
 ```
 
+### Usage without middleware
+
+If you prefer to use a more imperative approach, you can use `validate` function that accepts a request and a schema and returns the validated data (or throws an Exception if validation fails). Notice that validated data can be different from request data since Joi performs some parsing (like convert string into numbers when required).
+
+```js
+var validate = require('express-validation').validate;
+
+app.post('/login', validate(validation.login), function(req, res, next) {
+  try {
+    var data = validate(req, {
+      body: {
+        email: Joi.string().email().required(),
+        password: Joi.string().regex(/[a-zA-Z0-9]{3,30}/).required()
+      }
+    })
+    ...
+    res.json(200);
+  } catch (err) {
+    next(err)
+  }
+});
+```
+
 ## Options
 
 ### Unknown schema fields - strict checking
-By default, additional fields outside of the schema definition will be ignored by validation.  
+By default, additional fields outside of the schema definition will be ignored by validation.
 To enforce strict checking, set the `allowUnknown\*` options as follows:
 
 ```js
@@ -292,13 +315,13 @@ Thanks to node `require()` caching, all the other `express-validation` instances
 ### Full options list
 Recap of all options usable both as global or per-validation basis.
 
-**allowUnknownBody**: boolean - _default_: `true`  
-**allowUnknownHeaders**: boolean - _default_: `true`  
-**allowUnknownQuery**: boolean - _default_: `true`  
-**allowUnknownParams**: boolean - _default_: `true`  
-**allowUnknownCookies**: boolean - _default_: `true`  
-**status**: integer - _default_: `400`  
-**statusText**: string - _default_: `'Bad Request'`  
+**allowUnknownBody**: boolean - _default_: `true`
+**allowUnknownHeaders**: boolean - _default_: `true`
+**allowUnknownQuery**: boolean - _default_: `true`
+**allowUnknownParams**: boolean - _default_: `true`
+**allowUnknownCookies**: boolean - _default_: `true`
+**status**: integer - _default_: `400`
+**statusText**: string - _default_: `'Bad Request'`
 **contextRequest**: boolean - _default_: `false`
 
 ## Changelog

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,24 +30,45 @@ exports = module.exports = function (schema) {
   if (!schema) throw new Error('Please provide a validation schema');
 
   return function (req, res, next)  {
-    var errors = [];
-
-    // Set default options
-    var options = defaults({}, schema.options || {}, globalOptions, defaultOptions);
-
-    // NOTE: mutates `errors`
-    ['headers', 'body', 'query', 'params', 'cookies'].forEach(function (key) {
-      var allowUnknown = options[unknownMap[key]];
-      var entireContext = options.contextRequest ? req : null;
-      if (schema[key]) validate(errors, req[key], schema[key], key, allowUnknown, entireContext);
-    });
-
-    if (errors && errors.length === 0) return next();
-
-    return next(new ValidationError(errors, options));
+    try {
+      var values = validate(schema, req);
+      assignIn(req, values);
+      next();
+    } catch (err) {
+      next(err);
+    }
   };
 };
 
+/**
+ * Validate a request against a schema
+ * @param {Object} schema - the Joi schema
+ * @param {Object} req - the request object
+ * @return {Object} the Joi parsed values
+ * @throws ValidationError if the validation fails
+ */
+function validate (schema, req) {
+  var errors = [];
+  var values = {};
+
+  // Set default options
+  var options = defaults({}, schema.options || {}, globalOptions, defaultOptions);
+
+  // NOTE: mutates `errors` and `values`
+  ['headers', 'body', 'query', 'params', 'cookies'].forEach(function (key) {
+    var allowUnknown = options[unknownMap[key]];
+    var entireContext = options.contextRequest ? req : null;
+    if (schema[key]) {
+      values[key] = {};
+      validateKey(errors, values[key], req[key], schema[key], key, allowUnknown, entireContext);
+    }
+  });
+
+  if (errors && errors.length > 0) throw new ValidationError(errors, options);
+  return values;
+}
+
+exports.validate = validate;
 exports.ValidationError = ValidationError;
 
 exports.options = function (opts) {
@@ -60,10 +81,9 @@ exports.options = function (opts) {
 };
 
 /**
- * validate checks the current `Request` for validations
- * NOTE: mutates `request` in case the object is valid.
+ * validateKey checks the current `Request` for validations
  */
-function validate (errObj, request, schema, location, allowUnknown, context) {
+function validateKey (errObj, valueObj, request, schema, location, allowUnknown, context) {
   if (!request || !schema) return;
 
   var joiOptions = {
@@ -74,7 +94,7 @@ function validate (errObj, request, schema, location, allowUnknown, context) {
 
   Joi.validate(request, schema, joiOptions, function (errors, value) {
     if (!errors || errors.details.length === 0) {
-      assignIn(request, value); // joi responses are parsed into JSON
+      assignIn(valueObj, value); // joi responses are parsed into JSON
       return;
     }
     errors.details.forEach(function (error) {

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var validate = require('../lib/index').validate;
+var schema = require('./validation/account');
+var should = require('should');
+
+describe('validate API', function () {
+
+  it('should return an object with the validation result', function () {
+    var values = validate(schema, { params: { id: '00013' } });
+    should(values).deepEqual({ params: { id: 13 } });
+  });
+
+  it('throws an error if validation fails', function (done) {
+    try {
+      validate(schema, { params: { id: 'string' } });
+    } catch (err) {
+      done();
+    }
+  });
+
+});


### PR DESCRIPTION
This PR adds (and exports) a new `validate` function without introducing any change to the previous API.

The validate function performs the same express-validation process but without creating a middleware. The rationale behind this addition is that with the advent of async/await, middleware chains are less useful (because we can write simpler imperative code). So instead of this:

```js
router.post('/login', 
  validation(loginRequest), 
  findUserByEmailMiddleware,
  (req, res) => {
   const user = req.user;
   if (user) res.send(...);
});
```

We can write this:

router,post('/ligin', async (req, res) => {
  const data = validate(req, loginRequest);
  const user = await findUserByEmail(data.body.email);
  ...
  res.send(...);
});

Middleware is still a good option if you plan to reuse, but most of the times request validation is not shareable.

What do you think?

(and by the way, thanks for this library! 🎉👏)

