### PR TITLE
upgraded Joi dependency to @hapi/joi@^15.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We have defined two rules `email` and `password`.  They are encapsulated inside 
 
 **file**: [`test/validation/login.js`](test/validation/login.js)
 ```js
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   body: {
@@ -152,7 +152,7 @@ Validate that the ID in the request params is the same ID as in the body for the
 
 **file**: [`test/validation/context.js`](test/validation/context.js)
 ```js
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   body: {
@@ -207,7 +207,7 @@ Running the above test will produce the following response:
 When creating a validation object that checks `req.headers`; please remember to use `lowercase` names; node.js will convert incoming headers to lowercase:
 
 ```js
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   headers: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 var assignIn = require('lodash/assignIn');
 var find = require('lodash/find');
 var defaults = require('lodash/defaults');

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "lodash": "^4.9.0"
   },
   "peerDependencies": {
-    "joi": "*"
+    "@hapi/joi": "*"
   },
   "devDependencies": {
+    "@hapi/joi": "^15.1.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.1",
     "eslint": "^2.7.0",
     "express": "~4.x",
-    "joi": "^9.0.4",
     "mocha": "^2.3.4",
     "should": "^9.0.2",
     "supertest": "^1.1.0"

--- a/test/mix.js
+++ b/test/mix.js
@@ -50,7 +50,7 @@ describe('validate a mixture of request types', function () {
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(1);
           response.errors[0].types.length.should.equal(1);
-          response.errors[0].field.should.equal('id');
+          response.errors[0].field.should.containEql('id');
           done();
         });
     });
@@ -75,7 +75,7 @@ describe('validate a mixture of request types', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(2);
-          response.errors[0].field.should.equal('password');
+          response.errors[0].field.should.containEql('password');
           done();
         });
     });
@@ -100,7 +100,7 @@ describe('validate a mixture of request types', function () {
           var response = JSON.parse(res.text);
           response.errors.length.should.equal(1);
           response.errors[0].messages.length.should.equal(1);
-          response.errors[0].field.should.equal('accesstoken');
+          response.errors[0].field.should.containEql('accesstoken');
           done();
         });
     });

--- a/test/validation/account.js
+++ b/test/validation/account.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   params: {

--- a/test/validation/array.js
+++ b/test/validation/array.js
@@ -1,4 +1,4 @@
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 
 module.exports = {

--- a/test/validation/context.js
+++ b/test/validation/context.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   options: { contextRequest: true },

--- a/test/validation/defaults.js
+++ b/test/validation/defaults.js
@@ -1,4 +1,4 @@
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 var generateUsername = function (context) {
   return context.firstname.toLowerCase() + '-' + context.lastname.toLowerCase();

--- a/test/validation/login.js
+++ b/test/validation/login.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   options: { allowUnknownBody: false },

--- a/test/validation/logout.js
+++ b/test/validation/logout.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   options: { allowUnknownCookies: false },

--- a/test/validation/options.js
+++ b/test/validation/options.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   options: {

--- a/test/validation/parsing.js
+++ b/test/validation/parsing.js
@@ -1,4 +1,4 @@
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 exports.params = {
   params: {

--- a/test/validation/register.js
+++ b/test/validation/register.js
@@ -1,5 +1,5 @@
 'use strict';
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports.post = {
   options: { flatten: true },

--- a/test/validation/search.js
+++ b/test/validation/search.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports = {
   query: {

--- a/test/validation/user.js
+++ b/test/validation/user.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
+var Joi = require('@hapi/joi');
 
 module.exports.get = {
   headers: {


### PR DESCRIPTION
Since the old joi dependency is not maintained anymore, it's recommended to update to the new @hapi/joi dependency. Since this package required it as a peer dependency, we either have to use the old Joi module, or have both the old and new one in our project. Since the latest version doesn't have a lot of changes I made the update.