### PR TITLE
Upgraded the lodash version to fix Prototype Pollution vulnerability (CVE-2019-10744) 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -508,7 +508,7 @@
         "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.15",
         "mkdirp": "0.5.1",
         "optionator": "0.8.2",
         "path-is-absolute": "1.0.1",
@@ -879,7 +879,7 @@
         "cli-cursor": "1.0.2",
         "cli-width": "2.2.0",
         "figures": "1.7.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.15",
         "readline2": "1.0.1",
         "run-async": "0.1.0",
         "rx-lite": "3.1.2",
@@ -1055,9 +1055,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -1695,7 +1695,7 @@
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
         "chalk": "1.1.3",
-        "lodash": "4.17.5",
+        "lodash": "4.17.15",
         "slice-ansi": "0.0.4",
         "string-width": "2.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/andrewkeig/express-validation"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
-    "@types/joi": "^13.0.5"
+    "@types/joi": "^13.0.5",
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "joi": "*"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "https://github.com/andrewkeig/express-validation"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
-    "@types/joi": "^13.0.5",
+    "lodash": "^4.17.15",
+    "@types/joi": "^13.0.5"
   },
   "peerDependencies": {
     "joi": "*"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/andrewkeig/express-validation"
   },
   "dependencies": {
-    "lodash": "^4.9.0"
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "joi": "*"


### PR DESCRIPTION
Upgraded the lodash version to fix Prototype Pollution vulnerability (CVE-2019-10744)
Please refer to https://app.snyk.io/vuln/SNYK-JS-LODASH-450202