### PR TITLE
move @types/* devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "middleware"
   ],
   "dependencies": {
-    "@hapi/joi": "17.x.x"
+    "@hapi/joi": "17.x.x",
+    "@types/express": "4.x.x",
+    "@types/hapi__joi": "16.x.x"
   },
   "jest": {
     "collectCoverageFrom": [
@@ -51,8 +53,6 @@
     }
   },
   "devDependencies": {
-    "@types/express": "4.x.x",
-    "@types/hapi__joi": "16.x.x",
     "benchmark": "^2.1.4",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.4",


### PR DESCRIPTION
Fixes https://github.com/AndrewKeig/express-validation/issues/106

Both of these `@types/*` deps need to be prod deps so that consumers of `express-validation` that are using TypeScript can compile successfully.