### PR TITLE
Add mutate option

### DIFF
--- a/__tests__/integration/defaults.test.js
+++ b/__tests__/integration/defaults.test.js
@@ -21,7 +21,7 @@ const schema = {
   }),
 };
 
-const app = createServer('post', '/defaults', schema, { context: true }, {}, 'body');
+const app = createServer('post', '/defaults', schema, { mutate: true }, {}, 'body');
 
 describe('Defaults', () => {
   describe('when the values are missing', () => {

--- a/__tests__/integration/mutate.test.js
+++ b/__tests__/integration/mutate.test.js
@@ -1,0 +1,45 @@
+const Joi = require('@hapi/joi');
+const request = require('supertest');
+const { createServer } = require('../../_mocks_/express');
+
+const schema = {
+  body: Joi.object({
+    firstname: Joi.string().default('Andrew'),
+    lastname: Joi.string().default('Keig'),
+    age: Joi.number(),
+    registered: Joi.boolean().default(true),
+  }),
+};
+
+const mutateApp = createServer('post', '/defaults', schema, { mutate: true }, {}, 'body');
+const nonMutateApp = createServer('post', '/defaults', schema, {}, {}, 'body');
+
+describe('Mutate', () => {
+  describe('when mutate is true', () => {
+    it('should return the request joi parsed values', async () => {
+      const response = await request(mutateApp)
+        .post('/defaults')
+        .send({ firstname: 'Jane', lastname: 'Doe', age: '23' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.firstname).toBe('Jane');
+      expect(response.body.lastname).toBe('Doe');
+      expect(response.body.registered).toBe(true);
+      expect(response.body.age).toBe(23);
+    });
+  });
+
+  describe('when mutate is false', () => {
+    it('should return original request values', async () => {
+      const response = await request(nonMutateApp)
+        .post('/defaults')
+        .send({ firstname: 'Jane', lastname: 'Doe', age: '23' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body.firstname).toBe('Jane');
+      expect(response.body.lastname).toBe('Doe');
+      expect(response.body.registered).toBe(undefined);
+      expect(response.body.age).toBe('23');
+    });
+  });
+});

--- a/__tests__/unit/evOptions.test.js
+++ b/__tests__/unit/evOptions.test.js
@@ -6,10 +6,12 @@ describe('Ev Options', () => {
       const options = {
         context: true,
         keyByField: true,
+        mutate: true,
         statusCode: 422,
       };
       const expected = {
         context: true,
+        mutate: true,
         error: 'Unprocessable Entity',
         keyByField: true,
         statusCode: 422,

--- a/lib/ev.js
+++ b/lib/ev.js
@@ -6,11 +6,13 @@ const evOptions = {
   keyByField: false,
   statusCode: 400,
   error: http.STATUS_CODES[400],
+  mutate: false,
 };
 
 const evSchema = Joi.object({
   context: Joi.boolean(),
   keyByField: Joi.boolean(),
+  mutate: Joi.boolean(),
   statusCode: Joi.number().custom((statusCode) => {
     if (!http.STATUS_CODES[statusCode]) {
       throw new Error(`Error: Http status code ${statusCode} not supported`);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,16 +1,17 @@
 // Type definitions for express-validation
 /// <reference types="node" />
 import { RequestHandler } from "express";
-import { 
-  ValidationOptions, 
+import {
+  ValidationOptions,
   ValidationError as JoiError,
-  Root as joiRoot, 
+  Root as joiRoot,
 } from '@hapi/joi';
 
 interface EvOptions {
   context?: boolean;
   keyByField?: boolean;
   statusCode?: number;
+  mutate?: boolean;
 }
 
 interface schema {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports.validate = (schema = {}, options = {}, joi = {}) => {
     const joiOptions = mergeJoiOptions(joi, options.context, request);
 
     const validate = (parameter) => schema[parameter].validateAsync(request[parameter], joiOptions)
-      .then(result => handleMutation(request[parameter], result.value, evOptions.context))
+      .then(result => handleMutation(request[parameter], result.value, evOptions.mutate))
       .catch(error => ({ [parameter]: error.details }));
 
     const hasErrors = (errors) => (errors ? new ValidationError(errors, evOptions) : null);

--- a/lib/mutation.js
+++ b/lib/mutation.js
@@ -1,9 +1,7 @@
 exports.handleMutation = (request, value, mutate) => {
   if (mutate) {
     Object.keys(value).forEach(parameter => {
-      if (request[parameter] === undefined) {
-        Object.defineProperty(request, parameter, { value: value[parameter], enumerable: true });
-      }
+      Object.defineProperty(request, parameter, { value: value[parameter], enumerable: true });
     });
   }
 


### PR DESCRIPTION
This PR adds a new `mutate` option that defines if the `request` object will be mutated with the `Joi` result values. The goal is to resolve issues described on #108 

The previous behavior only mutates `request` with default values, when the `context` option is true, the proposed behavior mutates all `request` properties, based on the new `mutate` option. Using the `context` option to define if the object will be mutated is a bit confuse, so I think have an exclusive option for this is better.

The default `mutate` value is `false` to do not break the current behavior.