### PR TITLE
Pass joi's options when validating schema

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const { clean, keyByField } = require('./reducers');
 
 exports.validate = (schema = {}, options = {}, joi = {}) => {
   Joi.assert(options, evSchema);
-  Joi.assert(schema, joiSchema);
+  Joi.assert(schema, joiSchema, joi);
 
   return (request, response, next) => {
     const evOptions = mergeEvOptions(options);


### PR DESCRIPTION
Alternatively to https://github.com/AndrewKeig/express-validation/pull/127 

The issue is that when you overload the `req` object with an extra property you will get `ValidationError`.

E.g., 
```javascript
Joi.assert(
  Joi.object({body: {}, foo: {}}), 
  Joi.object(parameters.reduce((result, item) => ({ ...result, [item]: Joi.object() }), {})).required().min(1)
)
```
Will fail.

While:
```javascript
Joi.assert(
  Joi.object({body: {}, foo: {}}), 
  Joi.object(parameters.reduce((result, item) => ({ ...result, [item]: Joi.object() }), {})).required().min(1),
  {allowUnknown: true}
)
```
Will success