### PR TITLE
Add the ability to wrap validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode
 coverage/**
 .clinic
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ load
 .eslintrc
 .nvmrc
 .travis.yml
+.idea

--- a/__tests__/unit/evOptions.test.js
+++ b/__tests__/unit/evOptions.test.js
@@ -1,4 +1,4 @@
-const { mergeEvOptions } = require('../../lib/ev.js');
+const { mergeEvOptions, defaultErrorDetailsFormatter } = require('../../lib/ev.js');
 
 describe('Ev Options', () => {
   describe('when settings ev options', () => {
@@ -13,6 +13,7 @@ describe('Ev Options', () => {
         error: 'Unprocessable Entity',
         keyByField: true,
         statusCode: 422,
+        errorDetailsFormatter: defaultErrorDetailsFormatter,
       };
       const result = mergeEvOptions(options);
 

--- a/__tests__/unit/validate.test.js
+++ b/__tests__/unit/validate.test.js
@@ -32,10 +32,29 @@ describe('Validate', () => {
         middleware(null, {}, () => { });
       }).toThrow(/Cannot read property 'headers' of null/);
     });
+    it('should use the correct errorDetailsFormatter', async () => {
+      let formatterCalled = false;
+      const errorDetailsFormatter = (errorDetails) => {
+        const safeResult = {};
+        Object.keys(errorDetails).forEach((key) => {
+          const safeErrorDetails = JSON.parse(JSON.stringify(errorDetails[key]));
+          delete safeErrorDetails.context.value;
+          safeResult[key] = safeErrorDetails;
+        });
+        formatterCalled = true;
+        return safeResult;
+      };
+      const middleware = validate(schema, { errorDetailsFormatter }, {});
+      middleware({ params: { id: 'secret' } }, {}, (e) => {
+        expect(e).not.toBe(null);
+        expect(formatterCalled).toBe(true);
+        expect(JSON.stringify(e)).not.toMatch(/"value":"secret"/);
+      });
+    });
   });
 
   describe('when schemas and options are valid', () => {
-    it('should return nullr', async () => {
+    it('should return null', async () => {
       expect(() => {
         const middleware = validate(schema, {}, {});
         middleware({}, {}, (e) => {

--- a/lib/ev.js
+++ b/lib/ev.js
@@ -1,11 +1,14 @@
 const http = require('http');
 const Joi = require('joi');
 
+const defaultErrorDetailsFormatter = (errorDetails) => errorDetails;
+
 const evOptions = {
   context: false,
   keyByField: false,
   statusCode: 400,
   error: http.STATUS_CODES[400],
+  errorDetailsFormatter: defaultErrorDetailsFormatter,
 };
 
 const evSchema = Joi.object({
@@ -18,6 +21,7 @@ const evSchema = Joi.object({
 
     return statusCode;
   }),
+  errorDetailsFormatter: Joi.func().arity(1),
 });
 
 const mergeEvOptions = (options) => {
@@ -25,5 +29,6 @@ const mergeEvOptions = (options) => {
   return { ...evOptions, ...options, error: http.STATUS_CODES[statusCode] };
 };
 
+exports.defaultErrorDetailsFormatter = defaultErrorDetailsFormatter;
 exports.mergeEvOptions = mergeEvOptions;
 exports.evSchema = evSchema;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,6 +11,7 @@ interface EvOptions {
   context?: boolean;
   keyByField?: boolean;
   statusCode?: number;
+  errorDetailsFormatter?: (err: ValidationError) => ValidationError;
 }
 
 interface schema {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,7 @@ interface EvOptions {
   context?: boolean;
   keyByField?: boolean;
   statusCode?: number;
-  errorDetailsFormatter?: (err: ValidationError) => ValidationError;
+  errorDetailsFormatter?: (err: JoiError) => JoiError;
 }
 
 interface schema {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,7 @@ interface EvOptions {
   context?: boolean;
   keyByField?: boolean;
   statusCode?: number;
-  errorDetailsFormatter?: (err: JoiError) => JoiError;
+  errorDetailsFormatter?: (err: JoiError[]) => JoiError;
 }
 
 interface schema {

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ exports.validate = (schema = {}, options = {}, joi = {}) => {
 
     const validate = (parameter) => schema[parameter].validateAsync(request[parameter], joiOptions)
       .then(result => handleMutation(request[parameter], result.value, evOptions.context))
-      .catch(error => ({ [parameter]: error.details }));
+      .catch(error => ({ [parameter]: evOptions.errorDetailsFormatter(error.details) }));
 
     const hasErrors = (errors) => (errors ? new ValidationError(errors, evOptions) : null);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersjcb/express-validation",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "author": "Andrew Keig <andrew.keig@gmail.com>",
   "description": "fork of AK's express-validation is a middleware that validates a request and returns a response with errors; if any of the configured validation rules fail.",
   "main": "./lib/index",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "express-validation",
-  "version": "3.0.8",
+  "name": "@powersjcb/express-validation",
+  "version": "3.0.9",
   "author": "Andrew Keig <andrew.keig@gmail.com>",
-  "description": "express-validation is a middleware that validates a request and returns a response with errors; if any of the configured validation rules fail.",
+  "description": "fork of AK's express-validation is a middleware that validates a request and returns a response with errors; if any of the configured validation rules fail.",
   "main": "./lib/index",
   "types": "lib/index.d.ts",
-  "homepage": "https://github.com/andrewkeig/express-validation",
+  "homepage": "https://github.com/powersjcb/express-validation",
   "repository": {
     "type": "git",
-    "url": "https://github.com/andrewkeig/express-validation"
+    "url": "https://github.com/powersjcb/express-validation"
   },
   "bugs": {
     "url": "https://github.com/andrewkeig/express-validation/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersjcb/express-validation",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "author": "Andrew Keig <andrew.keig@gmail.com>",
   "description": "fork of AK's express-validation is a middleware that validates a request and returns a response with errors; if any of the configured validation rules fail.",
   "main": "./lib/index",


### PR DESCRIPTION
Adds the ability to wrap validation errors. This makes it so `express-validation` can be configured to exclude sensitive request data from logs.

https://github.com/AndrewKeig/express-validation/issues/129