### PR TITLE
Update ValidationError typescript definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -35,7 +35,7 @@ export declare const Joi: joiRoot;
 
 export declare function validate(schema: schema, options?: EvOptions, joiRoot?: ValidationOptions): RequestHandler;
 
-export class ValidationError {
+export class ValidationError extends JoiError {
   name: string;
   message: string;
   statusCode: number;


### PR DESCRIPTION
This change allows to create object by constructor new ValidationError(message, details, original) . For now we can only use constructor with ts-ignore and empty contructor throws error because statusCode is missing.