### PR TITLE
Completely replace req.body/req.params/etc. with the coerced/validated value from Joi

### DIFF
--- a/__tests__/integration/stripUnknown.test.js
+++ b/__tests__/integration/stripUnknown.test.js
@@ -36,7 +36,7 @@ describe('validate strip unknown', () => {
 
   describe('when the request contains unknown properties and joi stripUnknown is true', () => {
     it('should return a 200 response', async () => {
-      const app = createServer('post', '/login', schema, {}, { stripUnknown: true });
+      const app = createServer('post', '/login', schema, {}, { stripUnknown: true }, 'body');
       const login = {
         email: 'andrew.keig@gmail.com',
         password: '12356',
@@ -48,6 +48,30 @@ describe('validate strip unknown', () => {
         .send(login);
 
       expect(response.statusCode).toBe(200);
+      expect(response.body.email).toBe('andrew.keig@gmail.com');
+      expect(response.body.password).toBe('12356');
+      // Actually getting rid of the property requires context:true
+      expect(response.body.removeThis).toBe('xx');
+    });
+
+    describe('and when combined with context:true', () => {
+      it('should return a 200 response and strip unknown properties from the request body seen by the handler', async () => {
+        const app = createServer('post', '/login', schema, { context: true }, { stripUnknown: true }, 'body');
+        const login = {
+          email: 'andrew.keig@gmail.com',
+          password: '12356',
+          removeThis: 'xx',
+        };
+
+        const response = await request(app)
+          .post('/login')
+          .send(login);
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.email).toBe('andrew.keig@gmail.com');
+        expect(response.body.password).toBe('12356');
+        expect(response.body.removeThis).toBe(undefined);
+      });
     });
   });
 });

--- a/__tests__/unit/validate.test.js
+++ b/__tests__/unit/validate.test.js
@@ -30,7 +30,7 @@ describe('Validate', () => {
       expect(() => {
         const middleware = validate(schema, {}, {});
         middleware(null, {}, () => { });
-      }).toThrow(/Cannot read property 'headers' of null/);
+      }).toThrow(/Cannot read property 'headers' of null|Cannot read properties of null \(reading 'headers'\)/);
     });
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports.validate = (schema = {}, options = {}, joi = {}) => {
     const joiOptions = mergeJoiOptions(joi, options.context, request);
 
     const validate = (parameter) => schema[parameter].validateAsync(request[parameter], joiOptions)
-      .then(result => handleMutation(request[parameter], result.value, evOptions.context))
+      .then(result => handleMutation(request, parameter, result.value, evOptions.context))
       .catch(error => ({ [parameter]: error.details }));
 
     const hasErrors = (errors) => (errors ? new ValidationError(errors, evOptions) : null);

--- a/lib/mutation.js
+++ b/lib/mutation.js
@@ -1,8 +1,6 @@
-exports.handleMutation = (request, value, mutate) => {
+exports.handleMutation = (request, parameter, value, mutate) => {
   if (mutate) {
-    Object.keys(value).forEach(parameter => {
-      Object.defineProperty(request, parameter, { value: value[parameter], enumerable: true });
-    });
+    request[parameter] = value;
   }
 
   return null;


### PR DESCRIPTION
Hi!

I use `context:true` and have run into some cases where setting `stripUnknown` option didn't prevent unknown properties from "slipping past" the validation. This has been a source of some potential mass-assignment bugs in an application I'm working on. Now I want to make sure that object properties not explicitly listed in my schema don't make it into my request handlers, where it's often a temptation to pass the whole request body on to the application code.

Basically this is the problem described in https://github.com/AndrewKeig/express-validation/issues/116

Previously https://github.com/AndrewKeig/express-validation/pull/46 was partially landed(?) but it doesn't work that way in the latest `express-validation` 3.

I think this is a better fix than https://github.com/AndrewKeig/express-validation/pull/151