### PR TITLE
Export a type definition for the ValidationError constructor

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -35,10 +35,11 @@ export declare const Joi: joiRoot;
 
 export declare function validate(schema: schema, options?: EvOptions, joiRoot?: ValidationOptions): RequestHandler;
 
-export class ValidationError {
+export declare class ValidationError extends Error {
   name: string;
   message: string;
   statusCode: number;
   error: string;
   details: errors;
+  constructor(errors: errors, options: object);
 }


### PR DESCRIPTION
Context: https://github.com/AndrewKeig/express-validation/pull/134 tried to make it possible for a consumer to construct a `ValidationError` without the TypeScript compiler complaining. The change was merged and later reverted because of this report: https://github.com/AndrewKeig/express-validation/issues/136

I'm not super familiar with TypeScript, but I fiddled around and found that the enclosed fix makes `tsc` happy with a consumer going:

```js
import { ValidationError } from 'express-validation';

new ValidationError({ body: [] }, {});
```

@cmdcarini @novakDev can you confirm that this addresses the needs of both of you? :sweat_smile: