### PR TITLE
Require values in the schema object to be Joi schemas up front

### DIFF
--- a/__tests__/unit/schema.test.js
+++ b/__tests__/unit/schema.test.js
@@ -68,7 +68,7 @@ describe('Schema', () => {
   describe('Joi Schema', () => {
     describe('when joi schema has a single key', () => {
       it('should return valid schema', async () => {
-        const options = { body: {} };
+        const options = { body: Joi.object({}) };
 
         expect(() => {
           Joi.assert(options, joiSchema);
@@ -79,13 +79,13 @@ describe('Schema', () => {
     describe('when joi schema has all keys', () => {
       it('should return valid schema', async () => {
         const options = {
-          headers: {},
-          params: {},
-          query: {},
-          cookies: {},
-          signedCookies: {},
-          body: {},
-        }
+          headers: Joi.object({}),
+          params: Joi.object({}),
+          query: Joi.object({}),
+          cookies: Joi.object({}),
+          signedCookies: Joi.object({}),
+          body: Joi.object({}),
+        };
 
         expect(() => {
           Joi.assert(options, joiSchema);

--- a/lib/joi.js
+++ b/lib/joi.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 const { parameters } = require('./parameters');
 
 const schema = parameters
-  .reduce((result, item) => ({ ...result, [item]: Joi.object() }), {});
+  .reduce((result, item) => ({ ...result, [item]: Joi.object().schema() }), {});
 
 const joiSchema = Joi.object(schema).required().min(1);
 


### PR DESCRIPTION
Fixes #122 (or at least makes it easier to diagnose).

Before, a schema like `{ body: {} }` would be accepted, but then a `schema[parameter].validateAsync` error would be thrown at runtime.

This change will throw `Error: Cannot mix different versions of joi schemas` if the schema that's handed in comes from a different Joi version. Multiple copies of the same joi version in `node_modules` are okay. I guess that makes it a bit of a risky change.