### PR TITLE
Fix type definitions for Joi errors

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,11 +1,7 @@
 // Type definitions for express-validation
 /// <reference types="node" />
 import { RequestHandler } from "express";
-import {
-  ValidationOptions,
-  ValidationError as JoiError,
-  Root as joiRoot,
-} from 'joi';
+import { ValidationOptions, ValidationErrorItem, Root as joiRoot } from "joi";
 
 interface EvOptions {
   context?: boolean;
@@ -23,12 +19,12 @@ interface schema {
 }
 
 interface errors {
-  params?: JoiError[];
-  headers?: JoiError[];
-  query?: JoiError[];
-  cookies?: JoiError[];
-  signedCookies?: JoiError[];
-  body?: JoiError[];
+  params?: ValidationErrorItem[];
+  headers?: ValidationErrorItem[];
+  query?: ValidationErrorItem[];
+  cookies?: ValidationErrorItem[];
+  signedCookies?: ValidationErrorItem[];
+  body?: ValidationErrorItem[];
 }
 
 export declare const Joi: joiRoot;


### PR DESCRIPTION
I found that `express-validation` types seem to be broken.
Docs say that error object returns this structure:
```js
{
      "name": "ValidationError",
      "message": "Validation Failed",
      "statusCode": 400,
      "error": "Bad Request",
      "details": {
        "body": [
          {
            "message": "\"password\" is not allowed to be empty",
            "path": [
              "password"
            ],
            "type": "string.empty",
            "context": {
              "label": "password",
              "value": "",
              "key": "password"
            }
          }
        ]
      }
    }
```

But types claim that `error.detailss` return this:
```ts
class ValidationError extends Error {
  name: string;
  message: string;
  statusCode: number;
  error: string;
  details: {
    params?: JoiValidationError[];
    headers?: JoiValidationError[];
    query?: JoiValidationError[];
    cookies?: JoiValidationError[];
    signedCookies?: JoiValidationError[];
    body?: JoiValidationError[];
  };
  constructor(errors: errors, options: object);
}
```

Looking at Joi types, it's not Joi's `ValidationError`, it's `ValidationErrorItem`:
```ts
interface ValidationError extends Error {
        name: 'ValidationError';
        isJoi: boolean;
        details: ValidationErrorItem[];
        annotate(stripColors?: boolean): string;
        _original: any;
    }

    interface ValidationErrorItem {
        message: string;
        path: Array<string | number>;
        type: string;
        context?: Context;
    }
```